### PR TITLE
Add missing dependency on Unix

### DIFF
--- a/dune
+++ b/dune
@@ -9,6 +9,7 @@
   (names ml_curses)
   (flags
    (:include c_flags.sexp)))
+ (libraries unix)
  (c_library_flags
   (:include c_library_flags.sexp)))
 


### PR DESCRIPTION
Silences the alert proposed in ocaml/ocaml#11198, but this PR can be merged regardless.