### PR TITLE
Make it possible to vendor this package

### DIFF
--- a/dune
+++ b/dune
@@ -43,7 +43,7 @@
  (deps _curses.ml _config.ml _functions.c _keys.ml config.h)
  (action
   (chdir
-   %{workspace_root}
+   %{project_root}
    (with-stdout-to
     %{target}
     (system "%{cc} -x c -E _curses.ml")))))


### PR DESCRIPTION
Replace workspace_root with project_root in dune file. When a package is vendored inside another project, workspace_root is the top-level directory for the entire project whereas project_root is the vendored source directory for this package.