### PR TITLE
Fix the signature of getstr and getnstr

### DIFF
--- a/_curses.ml
+++ b/_curses.ml
@@ -114,6 +114,17 @@ end
  * to permit proper threading behavior *)
 ML0(getch,int)
 ML1(wgetch,int,window)
+ML1(getnstr_inner,(string * err),int)
+
+(* Wrap the inner function so we can return a result *)
+let tuple_to_result (str, err) =
+  match err with
+  | false -> Error ()
+  | true -> Ok str
+;;
+
+let getnstr n = tuple_to_result (getnstr_inner n)
+let getstr () = getnstr 1024
 
 let null_window = null_window ()
 

--- a/curses.mli
+++ b/curses.mli
@@ -464,12 +464,12 @@ val mvgetch : int -> int -> int
 val mvwgetch : window -> int -> int -> int
 val ungetch : int -> err
 
-(** Read a string in a window. *)
-val getstr : string -> err
+(** Read a string in a window. Note: `getstr` is implemented as `getnstr 1024` to avoid overflows *)
+val getstr : unit -> (string, unit) result
 val wgetstr : window -> string -> err
 val mvgetstr : int -> int -> string -> err
 val mvwgetstr : window -> int -> int -> string -> err
-val getnstr : string -> int -> int -> err
+val getnstr : int -> (string, unit) result
 val wgetnstr : window -> string -> int -> int -> err
 val mvgetnstr : int -> int -> string -> int -> int -> err
 val mvwgetnstr : window -> int -> int -> string -> int -> int -> err

--- a/functions.c
+++ b/functions.c
@@ -191,8 +191,6 @@ ML1(ungetch,err,int)
 
 /* getstr */
 
-ML1d(getstr,err,string)
-BEG1 r_err(getnstr(a_string(aa),caml_string_length(aa))); END
 ML2d(wgetstr,err,window,string)
 BEG2 r_err(wgetnstr(a_window(aa),a_string(ab),caml_string_length(ab))); END
 ML3d(mvgetstr,err,int,int,string)
@@ -200,8 +198,6 @@ BEG3 r_err(mvgetnstr(a_int(aa),a_int(ab),a_string(ac),caml_string_length(ac))); 
 ML4d(mvwgetstr,err,window,int,int,string)
 BEG4 r_err(mvwgetnstr(a_window(aa),a_int(ab),a_int(ac),a_string(ad),
   caml_string_length(ad))); END
-ML3d(getnstr,err,string,int,int)
-BEG3 r_err(getnstr(a_string(aa)+a_int(ab),a_int(ac))); END
 ML4d(wgetnstr,err,window,string,int,int)
 BEG4 r_err(wgetnstr(a_window(aa),a_string(ab)+a_int(ac),a_int(ad))); END
 ML5d(mvgetnstr,err,int,int,string,int,int)

--- a/ml_curses.c
+++ b/ml_curses.c
@@ -267,3 +267,23 @@ value mlcurses_wgetch(value win)
 
    CAMLreturn(Val_int(ch));
 }
+
+value mlcurses_getnstr_inner(int n)
+{
+   CAMLparam1(n);
+   int max_length = Int_val(n);
+   char* v = (char *) malloc(sizeof(char) * (max_length + 1));
+
+   caml_enter_blocking_section();
+   value err = getnstr(v, max_length);
+   caml_leave_blocking_section();
+
+   value str = caml_copy_string(!err ? v : "\0");
+   free(v);
+
+   CAMLlocal1(ret);
+   ret = caml_alloc_tuple(2);
+   Store_field(ret, 0, str); \
+   Store_field(ret, 1, Val_bool(err != ERR)); \
+   CAMLreturn(ret);
+}


### PR DESCRIPTION
The `getstr` and `getnstr` ncurses functions take in `char *` where they're expected to place the string retrieved from the blocking user input.

https://pubs.opengroup.org/onlinepubs/7908799/xcurses/getnstr.html

The current implementation in the OCaml Curses library maps these functions onto a function with signatures like `string -> err` which doesn't allow users to retrieve the strings generated from these function calls.

This commit changes the implementation of `getstr` to return a `(string, unit) result` which will allow users to get the produced string back while still allowing them to check the error state accurately.

_I'm aware that other functions nearby these functions have the same issue, and I'm happy to update those as well if you're good with this approach._