### PR TITLE
Expose setlocale for UTF-8 support

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+BasedOnStyle: Chromium

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+1.0.12 (2026-03-31)
+=====
+* Expose setlocale to enable UTF8 support
+
 1.0.11 (2023-01-19)
 =====
 * Don't hard-code gcc, use cc instead. Thanks @atupone for PR #7

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+UNRELEASED
+==========
+* Fix getstr and getnstr to return err instead of (string, unit). Thanks @seejohnrun for #13
+
 1.0.11 (2023-01-19)
 =====
 * Don't hard-code gcc, use cc instead. Thanks @atupone for PR #7

--- a/_curses.ml
+++ b/_curses.ml
@@ -114,6 +114,17 @@ end
  * to permit proper threading behavior *)
 ML0(getch,int)
 ML1(wgetch,int,window)
+ML1(getnstr_inner,(string * err),int)
+
+(* Wrap the inner function so we can return a result *)
+let tuple_to_result (str, err) =
+  match err with
+  | false -> Error ()
+  | true -> Ok str
+;;
+
+let getnstr n = tuple_to_result (getnstr_inner n)
+let getstr () = getnstr 1024
 
 let null_window = null_window ()
 

--- a/_curses.ml
+++ b/_curses.ml
@@ -141,9 +141,9 @@ let () =
 
 /*
 (* Bon, je vais recopier les constantes directement, parceque je n'ai
- * aucune idée de comment générer ça automatiquement proprement. Si ça ne
+ * aucune idï¿½e de comment gï¿½nï¿½rer ï¿½a automatiquement proprement. Si ï¿½a ne
  * marche pas chez vous, il vous suffit de regarder l'include, et de
- * corriger à la main. Faites-le moi savoir, à tout hasard... *)
+ * corriger ï¿½ la main. Faites-le moi savoir, ï¿½ tout hasard... *)
 */
 
 module A = struct
@@ -171,7 +171,7 @@ module A = struct
   let pair_number a = (a land color) lsr 8
 end
 
-(*/* Je sais, c'est moche, mais ça marche */*)
+(*/* Je sais, c'est moche, mais ï¿½a marche */*)
 module WA = A
 
 module Color = struct
@@ -193,4 +193,14 @@ end
 module Curses_config = struct
 #include "_config.ml"
 end
+
+let lC_CTYPE = 0
+let lC_NUMERIC = 1
+let lC_TIME = 2
+let lC_COLLATE = 3
+let lC_MONETARY = 4
+let lC_MESSAGES = 5
+let lC_ALL = 6
+
+external setlocale : int -> string -> string option = "mlcurses_setlocale"
 

--- a/curses.mli
+++ b/curses.mli
@@ -464,12 +464,12 @@ val mvgetch : int -> int -> int
 val mvwgetch : window -> int -> int -> int
 val ungetch : int -> err
 
-(** Read a string in a window. *)
-val getstr : string -> err
+(** Read a string in a window. Note: `getstr` is implemented as `getnstr 1024` to avoid overflows *)
+val getstr : unit -> (string, unit) result
 val wgetstr : window -> string -> err
 val mvgetstr : int -> int -> string -> err
 val mvwgetstr : window -> int -> int -> string -> err
-val getnstr : string -> int -> int -> err
+val getnstr : int -> (string, unit) result
 val wgetnstr : window -> string -> int -> int -> err
 val mvgetnstr : int -> int -> string -> int -> int -> err
 val mvwgetnstr : window -> int -> int -> string -> int -> int -> err

--- a/curses.mli
+++ b/curses.mli
@@ -777,3 +777,21 @@ sig
   val wide_ncurses : bool
 end
 
+(** {2 Locale} *)
+
+(** Locale category constants for use with {!setlocale}. *)
+
+val lC_ALL : int
+val lC_COLLATE : int
+val lC_CTYPE : int
+val lC_MESSAGES : int
+val lC_MONETARY : int
+val lC_NUMERIC : int
+val lC_TIME : int
+
+(** [setlocale category locale] sets the locale for the given category.
+    Must be called before {!initscr} for Unicode/wide character support.
+    Use [setlocale lC_ALL ""] to inherit the locale from the environment.
+    Returns [None] if the locale setting failed. *)
+val setlocale : int -> string -> string option
+

--- a/functions.c
+++ b/functions.c
@@ -191,8 +191,6 @@ ML1(ungetch,err,int)
 
 /* getstr */
 
-ML1d(getstr,err,string)
-BEG1 r_err(getnstr(a_string(aa),caml_string_length(aa))); END
 ML2d(wgetstr,err,window,string)
 BEG2 r_err(wgetnstr(a_window(aa),a_string(ab),caml_string_length(ab))); END
 ML3d(mvgetstr,err,int,int,string)
@@ -200,8 +198,6 @@ BEG3 r_err(mvgetnstr(a_int(aa),a_int(ab),a_string(ac),caml_string_length(ac))); 
 ML4d(mvwgetstr,err,window,int,int,string)
 BEG4 r_err(mvwgetnstr(a_window(aa),a_int(ab),a_int(ac),a_string(ad),
   caml_string_length(ad))); END
-ML3d(getnstr,err,string,int,int)
-BEG3 r_err(getnstr(a_string(aa)+a_int(ab),a_int(ac))); END
 ML4d(wgetnstr,err,window,string,int,int)
 BEG4 r_err(wgetnstr(a_window(aa),a_string(ab)+a_int(ac),a_int(ad))); END
 ML5d(mvgetnstr,err,int,int,string,int,int)

--- a/functions.c
+++ b/functions.c
@@ -1,3 +1,4 @@
+/* clang-format off */
 /* addch */
 
 ML1(addch,err,chtype)

--- a/ml_curses.c
+++ b/ml_curses.c
@@ -267,3 +267,23 @@ value mlcurses_wgetch(value win)
 
    CAMLreturn(Val_int(ch));
 }
+
+value mlcurses_getnstr_inner(int n)
+{
+   CAMLparam1(n);
+   int max_length = Int_val(n);
+   char* v = (char *) malloc(sizeof(char) * (max_length + 1));
+
+   caml_enter_blocking_section();
+   value err = getnstr(v, max_length);
+   caml_leave_blocking_section();
+
+   value str = caml_copy_string(!err ? v : "\0");
+   free(v);
+
+   CAMLlocal1(ret);
+   ret = caml_alloc_tuple(2);
+   Store_field(ret, 0, str); \
+   Store_field(ret, 1, Val_bool(err != ERR)); \
+   CAMLreturn(ret);
+}

--- a/ml_curses.c
+++ b/ml_curses.c
@@ -9,6 +9,7 @@
 #include <caml/fail.h>
 #include <stdio.h>
 #include <unistd.h>
+#include <locale.h>
 
 /* For PDCurses we need to define the following so that global
  * variables are declared (in the header) with __dllspec(dllimport).
@@ -266,4 +267,26 @@ value mlcurses_wgetch(value win)
    caml_leave_blocking_section();
 
    CAMLreturn(Val_int(ch));
+}
+
+static int locale_categories[] = {
+  LC_CTYPE, LC_NUMERIC, LC_TIME, LC_COLLATE, LC_MONETARY, LC_MESSAGES, LC_ALL
+};
+#define NUM_LOCALE_CATEGORIES (sizeof(locale_categories) / sizeof(locale_categories[0]))
+
+value mlcurses_setlocale(value cat, value loc)
+{
+  CAMLparam2(cat, loc);
+  int idx;
+  const char *result;
+
+  idx = Int_val(cat);
+  if (idx < 0 || idx >= (int)NUM_LOCALE_CATEGORIES)
+    caml_invalid_argument("setlocale: invalid category");
+
+  result = setlocale(locale_categories[idx], String_val(loc));
+  if (result == NULL)
+    CAMLreturn(Val_none);
+  else
+    CAMLreturn(caml_alloc_some(caml_copy_string(result)));
 }

--- a/ml_curses.c
+++ b/ml_curses.c
@@ -268,7 +268,7 @@ value mlcurses_wgetch(value win)
    CAMLreturn(Val_int(ch));
 }
 
-value mlcurses_getnstr_inner(int n)
+value mlcurses_getnstr_inner(value n)
 {
    CAMLparam1(n);
    int max_length = Int_val(n);

--- a/ml_curses.c
+++ b/ml_curses.c
@@ -2,11 +2,11 @@
 #include "config.h"
 #endif
 
-#include <caml/mlvalues.h>
 #include <caml/alloc.h>
-#include <caml/memory.h>
 #include <caml/callback.h>
 #include <caml/fail.h>
+#include <caml/memory.h>
+#include <caml/mlvalues.h>
 #include <stdio.h>
 #include <unistd.h>
 
@@ -43,247 +43,322 @@
 #include <sys/ioctl.h>
 #endif
 
-#define AWB(x) caml__dummy_##x=caml__dummy_##x; /* anti-warning bugware */
+#define AWB(x) caml__dummy_##x = caml__dummy_##x; /* anti-warning bugware */
 
-static value Val_window(WINDOW *w)
-{
-  return caml_copy_nativeint((intnat) w);
+static value Val_window(WINDOW* w) {
+  return caml_copy_nativeint((intnat)w);
 }
 
-static value Val_terminal(TERMINAL *t)
-{
-  return caml_copy_nativeint((intnat) t);
+static value Val_terminal(TERMINAL* t) {
+  return caml_copy_nativeint((intnat)t);
 }
 
-static value Val_screen(SCREEN *s)
-{
-  return caml_copy_nativeint((intnat) s);
+static value Val_screen(SCREEN* s) {
+  return caml_copy_nativeint((intnat)s);
 }
 
-#define Window_val(v) ((WINDOW *) Nativeint_val(v))
+#define Window_val(v) ((WINDOW*)Nativeint_val(v))
 
-#define Terminal_val(v) ((TERMINAL *) Nativeint_val(v))
+#define Terminal_val(v) ((TERMINAL*)Nativeint_val(v))
 
-#define Screen_val(v) ((SCREEN *) Nativeint_val(v))
+#define Screen_val(v) ((SCREEN*)Nativeint_val(v))
 
-#define r_unit(f)	f; CAMLreturn(Val_unit);
-#define r_window(f)	CAMLreturn(Val_window(f))
-#define r_terminal(f)	CAMLreturn(Val_terminal(f))
-#define r_err(f)	CAMLreturn(Val_bool((f)!=ERR))
-#define r_int(f)	CAMLreturn(Val_int(f))
-#define r_char(f)	CAMLreturn(Val_int((f)&255))
-#define r_chtype(f)	CAMLreturn(Val_int(f))
-#define r_attr_t(f)	CAMLreturn(Val_int(f))
-#define r_bool(f)	CAMLreturn(Val_bool(f))
-#define r_int_int(x,y)	\
-  { CAMLlocal1(ret); AWB(ret); \
-    ret=caml_alloc_tuple(2); \
-    Store_field(ret,0,Val_int(x)); \
-    Store_field(ret,1,Val_int(y)); \
-    CAMLreturn(ret); }
-#define r_window_int(x,y)	\
-  { CAMLlocal1(ret); AWB(ret); \
-    ret=caml_alloc_tuple(2); \
-    Store_field(ret,0,Val_window(x)); \
-    Store_field(ret,1,Val_int(y)); \
-    CAMLreturn(ret); }
-#define r_int_int_int(x,y,z) \
-  { CAMLlocal1(ret); AWB(ret); \
-    ret=caml_alloc_tuple(3); \
-    Store_field(ret,0,Val_int(x)); \
-    Store_field(ret,1,Val_int(y)); \
-    Store_field(ret,2,Val_int(z)); \
-    CAMLreturn(ret); }
-#define r_string(f)	\
-  { const char *ret=f; \
-    if(ret==NULL) caml_failwith("Null pointer"); \
-    CAMLreturn(caml_copy_string(ret)); }
+#define r_unit(f) \
+  f;              \
+  CAMLreturn(Val_unit);
+#define r_window(f) CAMLreturn(Val_window(f))
+#define r_terminal(f) CAMLreturn(Val_terminal(f))
+#define r_err(f) CAMLreturn(Val_bool((f) != ERR))
+#define r_int(f) CAMLreturn(Val_int(f))
+#define r_char(f) CAMLreturn(Val_int((f) & 255))
+#define r_chtype(f) CAMLreturn(Val_int(f))
+#define r_attr_t(f) CAMLreturn(Val_int(f))
+#define r_bool(f) CAMLreturn(Val_bool(f))
+#define r_int_int(x, y)              \
+  {                                  \
+    CAMLlocal1(ret);                 \
+    AWB(ret);                        \
+    ret = caml_alloc_tuple(2);       \
+    Store_field(ret, 0, Val_int(x)); \
+    Store_field(ret, 1, Val_int(y)); \
+    CAMLreturn(ret);                 \
+  }
+#define r_window_int(x, y)              \
+  {                                     \
+    CAMLlocal1(ret);                    \
+    AWB(ret);                           \
+    ret = caml_alloc_tuple(2);          \
+    Store_field(ret, 0, Val_window(x)); \
+    Store_field(ret, 1, Val_int(y));    \
+    CAMLreturn(ret);                    \
+  }
+#define r_int_int_int(x, y, z)       \
+  {                                  \
+    CAMLlocal1(ret);                 \
+    AWB(ret);                        \
+    ret = caml_alloc_tuple(3);       \
+    Store_field(ret, 0, Val_int(x)); \
+    Store_field(ret, 1, Val_int(y)); \
+    Store_field(ret, 2, Val_int(z)); \
+    CAMLreturn(ret);                 \
+  }
+#define r_string(f)                    \
+  {                                    \
+    const char* ret = f;               \
+    if (ret == NULL)                   \
+      caml_failwith("Null pointer");   \
+    CAMLreturn(caml_copy_string(ret)); \
+  }
 
-#define a_window(a)	Window_val(a)
-#define a_terminal(a)	Terminal_val(a)
-#define a_screen(a)	Screen_val(Field(a,2))
-#define a_int(a)	Int_val(a)
-#define a_bool(a)	Bool_val(a)
-#define a_chtype(a)	Int_val(a)
-#define a_attr_t(a)	Int_val(a)
-#define a_string(a)	Bytes_val(a)
+#define a_window(a) Window_val(a)
+#define a_terminal(a) Terminal_val(a)
+#define a_screen(a) Screen_val(Field(a, 2))
+#define a_int(a) Int_val(a)
+#define a_bool(a) Bool_val(a)
+#define a_chtype(a) Int_val(a)
+#define a_attr_t(a) Int_val(a)
+#define a_string(a) Bytes_val(a)
 
 #define RA0 CAMLparam0();
-#define RA1 CAMLparam1(aa); AWB(aa);
-#define RA2 CAMLparam2(aa,ab); AWB(aa);
-#define RA3 CAMLparam3(aa,ab,ac); AWB(aa);
-#define RA4 CAMLparam4(aa,ab,ac,ad); AWB(aa);
-#define RA5 CAMLparam5(aa,ab,ac,ad,ae); AWB(aa);
-#define RA6 CAMLparam5(aa,ab,ac,ad,ae); CAMLxparam1(af); AWB(aa); AWB(af);
-#define RA7 CAMLparam5(aa,ab,ac,ad,ae); CAMLxparam2(af,ag); AWB(aa); AWB(af);
-#define RA8 CAMLparam5(aa,ab,ac,ad,ae); CAMLxparam3(af,ag,ah); AWB(aa); AWB(af);
-#define RA9 CAMLparam5(aa,ab,ac,ad,ae); CAMLxparam4(af,ag,ah,ai); AWB(aa); AWB(af);
+#define RA1       \
+  CAMLparam1(aa); \
+  AWB(aa);
+#define RA2           \
+  CAMLparam2(aa, ab); \
+  AWB(aa);
+#define RA3               \
+  CAMLparam3(aa, ab, ac); \
+  AWB(aa);
+#define RA4                   \
+  CAMLparam4(aa, ab, ac, ad); \
+  AWB(aa);
+#define RA5                       \
+  CAMLparam5(aa, ab, ac, ad, ae); \
+  AWB(aa);
+#define RA6                       \
+  CAMLparam5(aa, ab, ac, ad, ae); \
+  CAMLxparam1(af);                \
+  AWB(aa);                        \
+  AWB(af);
+#define RA7                       \
+  CAMLparam5(aa, ab, ac, ad, ae); \
+  CAMLxparam2(af, ag);            \
+  AWB(aa);                        \
+  AWB(af);
+#define RA8                       \
+  CAMLparam5(aa, ab, ac, ad, ae); \
+  CAMLxparam3(af, ag, ah);        \
+  AWB(aa);                        \
+  AWB(af);
+#define RA9                       \
+  CAMLparam5(aa, ab, ac, ad, ae); \
+  CAMLxparam4(af, ag, ah, ai);    \
+  AWB(aa);                        \
+  AWB(af);
 
-#define ML0(f,tr) \
-  value mlcurses_##f(void) \
-  { RA0 r_##tr(f()); }
-#define ML1(f,tr,ta) \
-  value mlcurses_##f(value aa) \
-  { RA1 r_##tr(f(a_##ta(aa))); }
-#define ML2(f,tr,ta,tb) \
-  value mlcurses_##f(value aa,value ab) \
-  { RA2 r_##tr(f(a_##ta(aa),a_##tb(ab))); }
-#define ML3(f,tr,ta,tb,tc) \
-  value mlcurses_##f(value aa,value ab,value ac) \
-  { RA3 r_##tr(f(a_##ta(aa),a_##tb(ab),a_##tc(ac))); }
-#define ML4(f,tr,ta,tb,tc,td) \
-  value mlcurses_##f(value aa,value ab,value ac,value ad) \
-  { RA4 r_##tr(f(a_##ta(aa),a_##tb(ab),a_##tc(ac),a_##td(ad))); }
-#define ML5(f,tr,ta,tb,tc,td,te) \
-  value mlcurses_##f(value aa,value ab,value ac,value ad,value ae) \
-  { RA5 r_##tr(f(a_##ta(aa),a_##tb(ab),a_##tc(ac),a_##td(ad),a_##te(ae))); }
+#define ML0(f, tr)           \
+  value mlcurses_##f(void) { \
+    RA0 r_##tr(f());         \
+  }
+#define ML1(f, tr, ta)           \
+  value mlcurses_##f(value aa) { \
+    RA1 r_##tr(f(a_##ta(aa)));   \
+  }
+#define ML2(f, tr, ta, tb)                 \
+  value mlcurses_##f(value aa, value ab) { \
+    RA2 r_##tr(f(a_##ta(aa), a_##tb(ab))); \
+  }
+#define ML3(f, tr, ta, tb, tc)                         \
+  value mlcurses_##f(value aa, value ab, value ac) {   \
+    RA3 r_##tr(f(a_##ta(aa), a_##tb(ab), a_##tc(ac))); \
+  }
+#define ML4(f, tr, ta, tb, tc, td)                                 \
+  value mlcurses_##f(value aa, value ab, value ac, value ad) {     \
+    RA4 r_##tr(f(a_##ta(aa), a_##tb(ab), a_##tc(ac), a_##td(ad))); \
+  }
+#define ML5(f, tr, ta, tb, tc, td, te)                                         \
+  value mlcurses_##f(value aa, value ab, value ac, value ad, value ae) {       \
+    RA5 r_##tr(f(a_##ta(aa), a_##tb(ab), a_##tc(ac), a_##td(ad), a_##te(ae))); \
+  }
 
-#define ML7(f,tr,ta,tb,tc,td,te,tf,tg) \
-  value mlcurses_##f##_bytecode(value *a,int n) \
-  { RA0 r_##tr(f(a_##ta(a[0]),a_##tb(a[1]),a_##tc(a[2]),a_##td(a[3]), \
-  a_##te(a[4]),a_##tf(a[5]),a_##tg(a[6]))); } \
-  value mlcurses_##f##_native(value aa,value ab,value ac,value ad, \
-  value ae,value af,value ag) \
-  { RA7 r_##tr(f(a_##ta(aa),a_##tb(ab),a_##tc(ac),a_##td(ad), \
-  a_##te(ae),a_##tf(af),a_##tg(ag))); }
+#define ML7(f, tr, ta, tb, tc, td, te, tf, tg)                               \
+  value mlcurses_##f##_bytecode(value* a, int n) {                           \
+    RA0 r_##tr(f(a_##ta(a[0]), a_##tb(a[1]), a_##tc(a[2]), a_##td(a[3]),     \
+                 a_##te(a[4]), a_##tf(a[5]), a_##tg(a[6])));                 \
+  }                                                                          \
+  value mlcurses_##f##_native(value aa, value ab, value ac, value ad,        \
+                              value ae, value af, value ag) {                \
+    RA7 r_##tr(f(a_##ta(aa), a_##tb(ab), a_##tc(ac), a_##td(ad), a_##te(ae), \
+                 a_##tf(af), a_##tg(ag)));                                   \
+  }
 
-#define ML8(f,tr,ta,tb,tc,td,te,tf,tg,th) \
-  value mlcurses_##f##_bytecode(value *a,int n) \
-  { RA0 r_##tr(f(a_##ta(a[0]),a_##tb(a[1]),a_##tc(a[2]),a_##td(a[3]), \
-  a_##te(a[4]),a_##tf(a[5]),a_##tg(a[6]),a_##th(a[7]))); } \
-  value mlcurses_##f##_native(value aa,value ab,value ac,value ad, \
-  value ae,value af,value ag,value ah) \
-  { RA8 r_##tr(f(a_##ta(aa),a_##tb(ab),a_##tc(ac),a_##td(ad), \
-    a_##te(ae),a_##tf(af),a_##tg(ag),a_##th(ah))); }
+#define ML8(f, tr, ta, tb, tc, td, te, tf, tg, th)                           \
+  value mlcurses_##f##_bytecode(value* a, int n) {                           \
+    RA0 r_##tr(f(a_##ta(a[0]), a_##tb(a[1]), a_##tc(a[2]), a_##td(a[3]),     \
+                 a_##te(a[4]), a_##tf(a[5]), a_##tg(a[6]), a_##th(a[7])));   \
+  }                                                                          \
+  value mlcurses_##f##_native(value aa, value ab, value ac, value ad,        \
+                              value ae, value af, value ag, value ah) {      \
+    RA8 r_##tr(f(a_##ta(aa), a_##tb(ab), a_##tc(ac), a_##td(ad), a_##te(ae), \
+                 a_##tf(af), a_##tg(ag), a_##th(ah)));                       \
+  }
 
-#define ML9(f,tr,ta,tb,tc,td,te,tf,tg,th,ti) \
-  value mlcurses_##f##_bytecode(value *a,int n) \
-  { RA0 r_##tr(f(a_##ta(a[0]),a_##tb(a[1]),a_##tc(a[2]),a_##td(a[3]),a_##te(a[4]), \
-  a_##tf(a[5]),a_##tg(a[6]),a_##th(a[7]),a_##ti(a[8]))); } \
-  value mlcurses_##f##_native(value aa,value ab,value ac,value ad,value ae, \
-  value af,value ag,value ah,value ai) \
-  { RA9 r_##tr(f(a_##ta(aa),a_##tb(ab),a_##tc(ac),a_##td(ad),a_##te(ae), \
-    a_##tf(af),a_##tg(ag),a_##th(ah),a_##ti(ai))); }
+#define ML9(f, tr, ta, tb, tc, td, te, tf, tg, th, ti)                       \
+  value mlcurses_##f##_bytecode(value* a, int n) {                           \
+    RA0 r_##tr(f(a_##ta(a[0]), a_##tb(a[1]), a_##tc(a[2]), a_##td(a[3]),     \
+                 a_##te(a[4]), a_##tf(a[5]), a_##tg(a[6]), a_##th(a[7]),     \
+                 a_##ti(a[8])));                                             \
+  }                                                                          \
+  value mlcurses_##f##_native(value aa, value ab, value ac, value ad,        \
+                              value ae, value af, value ag, value ah,        \
+                              value ai) {                                    \
+    RA9 r_##tr(f(a_##ta(aa), a_##tb(ab), a_##tc(ac), a_##td(ad), a_##te(ae), \
+                 a_##tf(af), a_##tg(ag), a_##th(ah), a_##ti(ai)));           \
+  }
 
-#define ML0d(f,tr) value mlcurses_##f(void)
-#define ML1d(f,tr,ta) value mlcurses_##f(value aa)
-#define ML2d(f,tr,ta,tb) value mlcurses_##f(value aa,value ab)
-#define ML3d(f,tr,ta,tb,tc) value mlcurses_##f(value aa,value ab,value ac)
-#define ML4d(f,tr,ta,tb,tc,td) value mlcurses_##f(value aa,value ab,\
-  value ac,value ad)
-#define ML5d(f,tr,ta,tb,tc,td,te) value mlcurses_##f(value aa,value ab,\
-  value ac,value ad,value ae)
-#define ML6d(f,tr,ta,tb,tc,td,te,tf) value mlcurses_##f##_native(value,value,\
-  value,value,value,value); \
-  value mlcurses_##f##_bytecode(value *a,int n) \
-  { return(mlcurses_##f##_native(a[0],a[1],a[2],a[3],a[4],a[5])); } \
-  value mlcurses_##f##_native(value aa,value ab,value ac,value ad,value ae,value af)
+#define ML0d(f, tr) value mlcurses_##f(void)
+#define ML1d(f, tr, ta) value mlcurses_##f(value aa)
+#define ML2d(f, tr, ta, tb) value mlcurses_##f(value aa, value ab)
+#define ML3d(f, tr, ta, tb, tc) value mlcurses_##f(value aa, value ab, value ac)
+#define ML4d(f, tr, ta, tb, tc, td) \
+  value mlcurses_##f(value aa, value ab, value ac, value ad)
+#define ML5d(f, tr, ta, tb, tc, td, te) \
+  value mlcurses_##f(value aa, value ab, value ac, value ad, value ae)
+#define ML6d(f, tr, ta, tb, tc, td, te, tf)                              \
+  value mlcurses_##f##_native(value, value, value, value, value, value); \
+  value mlcurses_##f##_bytecode(value* a, int n) {                       \
+    return (mlcurses_##f##_native(a[0], a[1], a[2], a[3], a[4], a[5]));  \
+  }                                                                      \
+  value mlcurses_##f##_native(value aa, value ab, value ac, value ad,    \
+                              value ae, value af)
 
-#define BEG0 { RA0 {
-#define BEG1 { RA1 {
-#define BEG2 { RA2 {
-#define BEG3 { RA3 {
-#define BEG4 { RA4 {
-#define BEG5 { RA5 {
-#define BEG6 { RA6 {
-#define BEG7 { RA7 {
-#define BEG8 { RA8 {
-#define BEG9 { RA9 {
-#define END }}
+#define BEG0 \
+  {          \
+    RA0 {
+#define BEG1 \
+  {          \
+    RA1 {
+#define BEG2 \
+  {          \
+    RA2 {
+#define BEG3 \
+  {          \
+    RA3 {
+#define BEG4 \
+  {          \
+    RA4 {
+#define BEG5 \
+  {          \
+    RA5 {
+#define BEG6 \
+  {          \
+    RA6 {
+#define BEG7 \
+  {          \
+    RA7 {
+#define BEG8 \
+  {          \
+    RA8 {
+#define BEG9 \
+  {          \
+    RA9 {
+#define END \
+  }         \
+  }
 
 /* RWMJ: Not implemented functions raise Invalid_argument
  * ("function_name").  This can happen for example when we are not
  * linked to real ncurses, particularly on Windows.
  */
-#define ML0_notimpl(f,tr)					\
-  value mlcurses_##f(void) BEG0 caml_invalid_argument (#f); CAMLnoreturn; END
-#define ML1_notimpl(f,tr,ta)						\
-  value mlcurses_##f(value aa) BEG1 caml_invalid_argument (#f); CAMLnoreturn; END
-#define ML2_notimpl(f,tr,ta,tb)						\
-  value mlcurses_##f(value aa, value ab) BEG2 caml_invalid_argument (#f); CAMLnoreturn; END
+#define ML0_notimpl(f, tr)                                 \
+  value mlcurses_##f(void) BEG0 caml_invalid_argument(#f); \
+  CAMLnoreturn;                                            \
+  END
+#define ML1_notimpl(f, tr, ta)                                 \
+  value mlcurses_##f(value aa) BEG1 caml_invalid_argument(#f); \
+  CAMLnoreturn;                                                \
+  END
+#define ML2_notimpl(f, tr, ta, tb)                                       \
+  value mlcurses_##f(value aa, value ab) BEG2 caml_invalid_argument(#f); \
+  CAMLnoreturn;                                                          \
+  END
 
-static WINDOW *ripoff_w[5];
+static WINDOW* ripoff_w[5];
 static int ripoff_l[5];
-static int ripoff_niv=0;
-static int ripoff_callback(WINDOW *w,int l)
-{
-  if(ripoff_niv==5) return(0);
-  ripoff_w[ripoff_niv]=w;
-  ripoff_l[ripoff_niv]=l;
+static int ripoff_niv = 0;
+static int ripoff_callback(WINDOW* w, int l) {
+  if (ripoff_niv == 5)
+    return (0);
+  ripoff_w[ripoff_niv] = w;
+  ripoff_l[ripoff_niv] = l;
   ripoff_niv++;
-  return(0);
+  return (0);
 }
 
 value putc_function;
-static int putc_callback(int c)
-{
+static int putc_callback(int c) {
   CAMLparam0();
   CAMLlocal1(ret);
 
   AWB(ret);
-  ret=caml_callback_exn(putc_function,Val_int(c&255));
-  CAMLreturn(Is_exception_result(ret)?-1:0);
+  ret = caml_callback_exn(putc_function, Val_int(c & 255));
+  CAMLreturn(Is_exception_result(ret) ? -1 : 0);
 }
 
 #ifndef WIN32
 /* Du travail pour les esclaves de M$ */
-static void winch_handler(int n)
-{
-  signal(n,winch_handler);
+static void winch_handler(int n) {
+  signal(n, winch_handler);
   ungetch(KEY_RESIZE);
 }
 #endif
 
-#include "functions.c"
 #include "caml/signals.h"
+#include "functions.c"
 
 /* The following routines are special-cased to allow other threads to run
  * while getch() is blocking */
-value mlcurses_getch(void)
-{
-   CAMLparam0();
-   int ch;
+value mlcurses_getch(void) {
+  CAMLparam0();
+  int ch;
 
-   caml_enter_blocking_section();
-   ch = getch();
-   caml_leave_blocking_section();
+  caml_enter_blocking_section();
+  ch = getch();
+  caml_leave_blocking_section();
 
-   CAMLreturn(Val_int(ch));
+  CAMLreturn(Val_int(ch));
 }
 
+value mlcurses_wgetch(value win) {
+  CAMLparam1(win);
+  int ch;
+  WINDOW* w;
 
-value mlcurses_wgetch(value win)
-{
-   CAMLparam1(win);
-   int ch;
-   WINDOW* w;
+  caml__dummy_win = caml__dummy_win;
+  w = Window_val(win);
 
-   caml__dummy_win = caml__dummy_win;
-   w = Window_val(win);
+  caml_enter_blocking_section();
+  ch = wgetch(w);
+  caml_leave_blocking_section();
 
-   caml_enter_blocking_section();
-   ch = wgetch(w);
-   caml_leave_blocking_section();
-
-   CAMLreturn(Val_int(ch));
+  CAMLreturn(Val_int(ch));
 }
 
-value mlcurses_getnstr_inner(value n)
-{
-   CAMLparam1(n);
-   int max_length = Int_val(n);
-   char* v = (char *) malloc(sizeof(char) * (max_length + 1));
+value mlcurses_getnstr_inner(value n) {
+  CAMLparam1(n);
+  int max_length = Int_val(n);
+  char* v = (char*)malloc(sizeof(char) * (max_length + 1));
 
-   caml_enter_blocking_section();
-   value err = getnstr(v, max_length);
-   caml_leave_blocking_section();
+  caml_enter_blocking_section();
+  value err = getnstr(v, max_length);
+  caml_leave_blocking_section();
 
-   value str = caml_copy_string(!err ? v : "\0");
-   free(v);
+  value str = caml_copy_string(!err ? v : "\0");
+  free(v);
 
-   CAMLlocal1(ret);
-   ret = caml_alloc_tuple(2);
-   Store_field(ret, 0, str); \
-   Store_field(ret, 1, Val_bool(err != ERR)); \
-   CAMLreturn(ret);
+  CAMLlocal1(ret);
+  ret = caml_alloc_tuple(2);
+  Store_field(ret, 0, str);
+  Store_field(ret, 1, Val_bool(err != ERR));
+  CAMLreturn(ret);
 }

--- a/test/dune
+++ b/test/dune
@@ -1,3 +1,7 @@
 (executable
  (name test)
  (libraries curses))
+
+(executable
+ (name unicode_trading)
+ (libraries curses))

--- a/test/unicode_trading.ml
+++ b/test/unicode_trading.ml
@@ -1,0 +1,132 @@
+open Curses
+
+let () =
+  (* NOTE: this setlocale() is needed for UTF-8 to work at all *)
+  let _ = setlocale lC_ALL "" in
+  let w = initscr () in
+  assert (start_color ());
+  assert (cbreak ());
+  assert (noecho ());
+  assert (keypad w true);
+  assert (use_default_colors ());
+
+  (* Color pairs *)
+  assert (init_pair 1 Color.green Color.black);
+  assert (init_pair 2 Color.red Color.black);
+  assert (init_pair 3 Color.yellow Color.black);
+  assert (init_pair 4 Color.cyan Color.black);
+  assert (init_pair 5 Color.white Color.blue);
+  assert (init_pair 6 Color.magenta Color.black);
+
+  let rows, cols = getmaxyx w in
+
+  (* Title bar *)
+  attron (A.color_pair 5 lor A.bold);
+  ignore (mvaddstr 0 0 (String.make cols ' '));
+  ignore (mvaddstr 0 1
+    "⚡ 株式取引所 — 🏦 Tokyo Stock Exchange Terminal v2.0");
+  attroff (A.color_pair 5 lor A.bold);
+
+  (* Market status *)
+  attron (A.color_pair 1 lor A.bold);
+  assert (mvaddstr 2 1
+    "🟢 Market: OPEN (開場中)    🕐 09:42:17 JST    📈 日経平均: 39,847.52 (+1.23%)");
+  attroff (A.color_pair 1 lor A.bold);
+
+  (* Separator *)
+  attron (A.color_pair 3);
+  assert (mvaddstr 3 0 (String.make (min cols 120) '-'));
+  attroff (A.color_pair 3);
+
+  (* Column headers *)
+  attron (A.color_pair 3 lor A.bold);
+  assert (mvaddstr 4 1
+    "Ticker       Name              Price       Change      Volume       Signal");
+  attroff (A.color_pair 3 lor A.bold);
+
+  (* Stock data: code, name, price, change, volume, signal, color_pair *)
+  let stocks = [
+    ("🎮 7974", "Nintendo",         "8,247",  "+3.42%", "1.2M", "🔥🚀💹 Surging", 1);
+    ("🚗 7203", "Toyota Motor",     "2,891",  "+1.87%", "3.4M", "📈⬆️  Strong", 1);
+    ("📱 6758", "Sony Group",       "13,450", "+0.52%", "890K", "↗️  Stable", 1);
+    ("💰 8306", "Mitsubishi UFJ",   "1,234",  "-0.89%", "5.1M", "📉⬇️  Weak", 2);
+    ("🍺 2502", "Asahi Group",      "5,678",  "-2.31%", "2.7M", "💥⚠️  Dropping", 2);
+    ("💊 4502", "Takeda Pharma",    "4,123",  "+0.11%", "1.8M", "➡️  Flat", 4);
+    ("🛤️ 9020",  "JR East",         "7,892",  "+0.73%", "670K", "🐂⬆️  Recovery", 1);
+    ("🏗️ 6501",  "Hitachi",         "9,567",  "-1.45%", "1.5M", "🐻⚠️  Caution", 2);
+    ("🔌 6702", "Fujitsu",          "19,230", "+4.17%", "4.2M", "🌋💎💰 Exploding", 1);
+    ("🎵 4755", "Rakuten Group",    "765",    "-3.78%", "8.9M", "💀🆘📉 Crashing", 2);
+  ] in
+
+  List.iteri (fun i (code, name, price, change, vol, signal, color) ->
+    let y = 5 + i in
+    if y < rows - 6 then begin
+      attron (A.color_pair 4);
+      assert (mvaddstr y 1 code);
+      attroff (A.color_pair 4);
+      assert (mvaddstr y 12 name);
+      attron (A.color_pair color lor A.bold);
+      assert (mvaddstr y 30 price);
+      assert (mvaddstr y 42 change);
+      attroff (A.color_pair color lor A.bold);
+      assert (mvaddstr y 54 vol);
+      attron (A.color_pair color);
+      assert (mvaddstr y 65 signal);
+      attroff (A.color_pair color);
+    end
+  ) stocks;
+
+  (* Separator *)
+  let sep_y = 16 in
+  attron (A.color_pair 3);
+  assert (mvaddstr sep_y 0 (String.make (min cols 120) '-'));
+  attroff (A.color_pair 3);
+
+  (* News ticker *)
+  attron (A.color_pair 6 lor A.bold);
+  assert (mvaddstr (sep_y + 1) 1 "📢 Breaking News (ニュース速報):");
+  attroff (A.color_pair 6 lor A.bold);
+
+  attron (A.color_pair 4);
+  assert (mvaddstr (sep_y + 2) 1
+    "🔴 BOJ holds interest rates steady at policy meeting 💴💴💴");
+  assert (mvaddstr (sep_y + 3) 1
+    "🟡 FX: 1 USD = 149.82 JPY (prev day -0.43) 💱🇯🇵🇺🇸");
+  assert (mvaddstr (sep_y + 4) 1
+    "🟢 Capital flowing into 半導体 sector on AI demand 🤖💻📈✨🌟  [あ=OK]");
+  attroff (A.color_pair 4);
+
+  (* Portfolio summary *)
+  let port_y = sep_y + 6 in
+  attron (A.color_pair 3 lor A.bold);
+  assert (mvaddstr port_y 1 "💼 Portfolio Summary");
+  attroff (A.color_pair 3 lor A.bold);
+
+  attron (A.color_pair 1 lor A.bold);
+  assert (mvaddstr (port_y + 1) 1
+    "💰 Total Value: ¥12,847,392  📈 Daily P&L: +¥234,567 (+1.86%) 🎉🎊💹");
+  attroff (A.color_pair 1 lor A.bold);
+
+  attron (A.color_pair 4);
+  assert (mvaddstr (port_y + 2) 1
+    "📊 Holdings: 10  🏆 Win Rate: 73.2%  ⚡ Fees: ¥42,891  🎯 Target: ¥15,000,000");
+  attroff (A.color_pair 4);
+
+  (* Alert bar *)
+  if rows > port_y + 5 then begin
+    attron (A.color_pair 2 lor A.bold lor A.blink);
+    assert (mvaddstr (port_y + 4) 1
+      "🚨🚨🚨 ALERT: Rakuten (4755) broke stop-loss ⚠️⚠️  Sell recommended 🆘🆘🆘");
+    attroff (A.color_pair 2 lor A.bold lor A.blink);
+  end;
+
+  (* Status bar *)
+  attron (A.color_pair 5);
+  ignore (mvaddstr (rows - 1) 0 (String.make (cols - 1) ' '));
+  ignore (mvaddstr (rows - 1) 1
+    "🔑 q:Quit  🔄 r:Refresh  🔍 s:Search  📋 p:Portfolio  ⚡ Live updating...");
+  attroff (A.color_pair 5);
+
+  assert (refresh ());
+  let _ = getch () in
+  endwin ()


### PR DESCRIPTION
This PR exposes `setlocale`, which can allow UTf-8 support. See `test/unicode_trading.ml` for an example.

Fixes #12 